### PR TITLE
Migrate to Bases instead of Systems.

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/systems/channel"
 )
 
-// Supported OS constant names for Systems.
+// Supported Name constant names for Bases.
 // This list should match the ones found in juju/os except for "kubernetes".
 const (
 	Ubuntu       = "ubuntu"
@@ -22,164 +22,168 @@ const (
 	GenericLinux = "genericlinux"
 )
 
-// validOS is a string set of valid OS names.
+// validOS is a string set of valid Name names.
 var validOS = set.NewStrings(Ubuntu, CentOS, Windows, OSX, OpenSUSE, GenericLinux)
 
-// seriesToSystem is a map of series names to systems.
+// seriesToBases is a map of series names to systems.
 // This should match the ones found in juju/os except for "kubernetes".
-var seriesToSystem = map[string]System{
-	"precise": System{
-		OS:      Ubuntu,
+var seriesToBases = map[string]Base{
+	"precise": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("12.04/stable"),
 	},
-	"quantal": System{
-		OS:      Ubuntu,
+	"quantal": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("12.10/stable"),
 	},
-	"raring": System{
-		OS:      Ubuntu,
+	"raring": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("13.04/stable"),
 	},
-	"saucy": System{
-		OS:      Ubuntu,
+	"saucy": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("13.10/stable"),
 	},
-	"trusty": System{
-		OS:      Ubuntu,
+	"trusty": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("14.04/stable"),
 	},
-	"utopic": System{
-		OS:      Ubuntu,
+	"utopic": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("14.10/stable"),
 	},
-	"vivid": System{
-		OS:      Ubuntu,
+	"vivid": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("15.04/stable"),
 	},
-	"wily": System{
-		OS:      Ubuntu,
+	"wily": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("15.10/stable"),
 	},
-	"xenial": System{
-		OS:      Ubuntu,
+	"xenial": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("16.04/stable"),
 	},
-	"yakkety": System{
-		OS:      Ubuntu,
+	"yakkety": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("16.10/stable"),
 	},
-	"zesty": System{
-		OS:      Ubuntu,
+	"zesty": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("17.04/stable"),
 	},
-	"artful": System{
-		OS:      Ubuntu,
+	"artful": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("17.10/stable"),
 	},
-	"bionic": System{
-		OS:      Ubuntu,
+	"bionic": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("18.04/stable"),
 	},
-	"cosmic": System{
-		OS:      Ubuntu,
+	"cosmic": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("18.10/stable"),
 	},
-	"disco": System{
-		OS:      Ubuntu,
+	"disco": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("19.04/stable"),
 	},
-	"eoan": System{
-		OS:      Ubuntu,
+	"eoan": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("19.10/stable"),
 	},
-	"focal": System{
-		OS:      Ubuntu,
+	"focal": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("20.04/stable"),
 	},
-	"groovy": System{
-		OS:      Ubuntu,
+	"groovy": {
+		Name:    Ubuntu,
 		Channel: channel.MustParse("20.10/stable"),
 	},
-	"win2008r2": System{
-		OS:      Windows,
+	"hirsute": {
+		Name:    Ubuntu,
+		Channel: channel.MustParse("21.04/stable"),
+	},
+	"win2008r2": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2008r2/stable"),
 	},
-	"win2012hvr2": System{
-		OS:      Windows,
+	"win2012hvr2": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2012hvr2/stable"),
 	},
-	"win2012hv": System{
-		OS:      Windows,
+	"win2012hv": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2012hv/stable"),
 	},
-	"win2012r2": System{
-		OS:      Windows,
+	"win2012r2": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2012r2/stable"),
 	},
-	"win2012": System{
-		OS:      Windows,
+	"win2012": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2012/stable"),
 	},
-	"win2016": System{
-		OS:      Windows,
+	"win2016": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2016/stable"),
 	},
-	"win2016hv": System{
-		OS:      Windows,
+	"win2016hv": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2016hv/stable"),
 	},
-	"win2016nano": System{
-		OS:      Windows,
+	"win2016nano": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2016nano/stable"),
 	},
-	"win2019": System{
-		OS:      Windows,
+	"win2019": {
+		Name:    Windows,
 		Channel: channel.MustParse("win2019/stable"),
 	},
-	"win7": System{
-		OS:      Windows,
+	"win7": {
+		Name:    Windows,
 		Channel: channel.MustParse("win7/stable"),
 	},
-	"win8": System{
-		OS:      Windows,
+	"win8": {
+		Name:    Windows,
 		Channel: channel.MustParse("win8/stable"),
 	},
-	"win81": System{
-		OS:      Windows,
+	"win81": {
+		Name:    Windows,
 		Channel: channel.MustParse("win81/stable"),
 	},
-	"win10": System{
-		OS:      Windows,
+	"win10": {
+		Name:    Windows,
 		Channel: channel.MustParse("win10/stable"),
 	},
-	"centos7": System{
-		OS:      CentOS,
+	"centos7": {
+		Name:    CentOS,
 		Channel: channel.MustParse("centos7/stable"),
 	},
-	"centos8": System{
-		OS:      CentOS,
+	"centos8": {
+		Name:    CentOS,
 		Channel: channel.MustParse("centos8/stable"),
 	},
-	"opensuseleap": System{
-		OS:      OpenSUSE,
+	"opensuseleap": {
+		Name:    OpenSUSE,
 		Channel: channel.MustParse("opensuse42/stable"),
 	},
-	"genericlinux": System{
-		OS:      GenericLinux,
+	"genericlinux": {
+		Name:    GenericLinux,
 		Channel: channel.MustParse("latest/stable"),
 	},
 }
 
-// systemToSeries is a reverse of seriesToSystem
-var systemToSeries = reverseSeriesMap()
+// baseToSeries is a reverse of seriesToBase
+var baseToSeries = reverseSeriesMap()
 
-func reverseSeriesMap() map[System]string {
-	r := make(map[System]string)
-	for series, system := range seriesToSystem {
-		if _, ok := r[system]; ok {
-			panic(fmt.Sprintf("duplicate system %q = %v", series, system))
+func reverseSeriesMap() map[Base]string {
+	r := make(map[Base]string)
+	for series, base := range seriesToBases {
+		if _, ok := r[base]; ok {
+			panic(fmt.Sprintf("duplicate base %q = %v", series, base))
 		}
-		r[system] = series
+		r[base] = series
 	}
 	return r
 }

--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6 h1:nrqc9b4YKpKV4lPI3G
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -57,7 +56,6 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOL
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/system.go
+++ b/system.go
@@ -4,8 +4,6 @@
 package systems
 
 import (
-	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/juju/errors"
@@ -13,106 +11,75 @@ import (
 	"github.com/juju/systems/channel"
 )
 
-// System represents an OS/Channel or Resource.
-// Systems can also be converted to and from a series string.
-type System struct {
-	OS       string          `json:"os,omitempty"`
-	Channel  channel.Channel `json:"channel,omitempty"`
-	Resource string          `json:"resource,omitempty"`
+// Base represents an OS/Channel.
+// Bases can also be converted to and from a series string.
+type Base struct {
+	Name    string          `json:"name,omitempty"`
+	Channel channel.Channel `json:"channel,omitempty"`
 }
 
-// Validate returns with no error when the System is valid.
-func (s System) Validate() error {
-	if s.OS == "" && s.Resource == "" {
-		return errors.NotValidf("one of os or resource must be specified")
+// Validate returns with no error when the Base is valid.
+func (s Base) Validate() error {
+	if s.Name == "" {
+		return errors.NotValidf("name must be specified")
 	}
 
-	if s.OS != "" {
-		if s.Resource != "" {
-			return errors.NotValidf("resource cannot be specified with os")
-		}
-		if !validOS.Contains(s.OS) {
-			return errors.NotValidf("os %q", s.OS)
-		}
-		if s.Channel == channel.Empty {
-			return errors.NotValidf("missing channel")
-		}
+	if !validOS.Contains(s.Name) {
+		return errors.NotValidf("os %q", s.Name)
+	}
+	if s.Channel == channel.Empty {
+		return errors.NotValidf("channel")
 	}
 
-	if s.Resource != "" {
-		if s.Channel != channel.Empty {
-			return errors.NotValidf("channel cannot be specified with resource")
-		}
-	}
 	return nil
 }
 
-// String respresentation of the System, used for series backwards compatability.
-func (s System) String() string {
+// String respresentation of the Base, used for series backwards compatability.
+func (s Base) String() string {
 	// Handle legacy series.
-	if series, ok := systemToSeries[s]; ok {
+	if series, ok := baseToSeries[s]; ok {
 		return series
 	}
-	// Handle new system as a series.
-	str := "system"
-	if s.OS != "" {
-		str += fmt.Sprintf("#os=%s", s.OS)
-	}
+	str := s.Name
 	if s.Channel != channel.Empty {
-		str += fmt.Sprintf("#channel=%s", s.Channel.String())
-	}
-	if s.Resource != "" {
-		str += fmt.Sprintf("#resource=%s", s.Resource)
+		str += "/" + s.Channel.String()
 	}
 	return str
 }
 
-// regex to match k=v from system series strings in the form
-// "system#os=ubuntu#version=18.04#resource=imagename"
-var systemSeriesRegex = regexp.MustCompile(`#(os|channel|resource)=([^#]+)`)
-
-// ParseSystemFromSeries matches legacy series like "focal" or parses a system as series string
-// in the form "system#os=ubuntu#version=18.04#resource=imagename"
-func ParseSystemFromSeries(s string) (System, error) {
+// ParseBaseFromSeries matches legacy series like "focal" or parses a base as series string
+// in the form "os/track/risk/branch"
+func ParseBaseFromSeries(s string) (Base, error) {
 	var err error
-	if !strings.HasPrefix(s, "system") {
-		system, ok := seriesToSystem[s]
-		if !ok {
-			return System{}, errors.NotValidf("series %s is unsupported", s)
-		}
-		return system, nil
+	if base, ok := seriesToBases[s]; ok {
+		return base, nil
 	}
-	propString := strings.TrimPrefix(s, "system")
-	matches := systemSeriesRegex.FindAllStringSubmatch(propString, -1)
-	if len(matches) == 0 {
-		return System{}, errors.NotValidf("invalid system series string %q", s)
+
+	// Split the first forward-slash to get name and channel.
+	// E.g. "os/track/risk/branch" => ["os", "track/risk/branch"]
+	segments := strings.SplitN(s, "/", 2)
+	osName := segments[0]
+	channelName := ""
+	if len(segments) == 2 {
+		channelName = segments[1]
 	}
-	matchedCharacters := 0
-	system := System{}
-	for _, v := range matches {
-		matchedCharacters += len(v[0])
-		key := v[1]
-		value := v[2]
-		switch key {
-		case "os":
-			system.OS = value
-		case "channel":
-			system.Channel, err = channel.Parse(value)
-			if err != nil {
-				return System{}, errors.Annotatef(err, "invalid channel %q", value)
-			}
-		case "resource":
-			system.Resource = value
-		default:
-			return System{}, errors.NotValidf("key %q in system series string %q", key, s)
+
+	base := Base{}
+	if !validOS.Contains(osName) {
+		return Base{}, errors.NotValidf("series %q", s)
+	}
+	base.Name = osName
+
+	if channelName != "" {
+		base.Channel, err = channel.Parse(channelName)
+		if err != nil {
+			return Base{}, errors.Annotatef(err, "malformed channel in base string %q", s)
 		}
 	}
-	if matchedCharacters != len(propString) {
-		return System{}, errors.NotValidf("system series string %q", s)
-	}
-	err = system.Validate()
+
+	err = base.Validate()
 	if err != nil {
-		return System{}, errors.Annotatef(err, "invalid system series string %q", s)
+		return Base{}, errors.Annotatef(err, "invalid base string %q", s)
 	}
-	return system, nil
+	return base, nil
 }

--- a/system_test.go
+++ b/system_test.go
@@ -20,47 +20,44 @@ type systemSuite struct {
 
 var _ = gc.Suite(&systemSuite{})
 
-func (s *systemSuite) TestSystemParsingToFromSeries(c *gc.C) {
+func (s *systemSuite) TestBaseParsingToFromSeries(c *gc.C) {
 	tests := []struct {
-		system       systems.System
-		str          string
-		parsedSystem systems.System
-		err          string
+		system     systems.Base
+		str        string
+		parsedBase systems.Base
+		err        string
 	}{
-		{systems.System{OS: systems.Ubuntu}, "system#os=ubuntu", systems.System{}, `invalid system series string "system#os=ubuntu": missing channel not valid`},
-		{systems.System{OS: systems.Windows}, "system#os=windows", systems.System{}, `invalid system series string "system#os=windows": missing channel not valid`},
-		{systems.System{OS: "mythicalos"}, "system#os=mythicalos", systems.System{}, `invalid system series string "system#os=mythicalos": os "mythicalos" not valid`},
-		{systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("20.04/stable"), Resource: "test-resource"}, "system#os=ubuntu#channel=20.04/stable#resource=test-resource", systems.System{}, `invalid system series string "system#os=ubuntu#channel=20.04/stable#resource=test-resource": resource cannot be specified with os not valid`},
-		{systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("20.04/stable")}, "focal", systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("20.04/stable")}, ""},
-		{systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("18.04/stable")}, "bionic", systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("18.04/stable")}, ""},
-		{systems.System{OS: systems.Windows, Channel: channel.MustParse("win10/stable")}, "win10", systems.System{OS: systems.Windows, Channel: channel.MustParse("win10/stable")}, ""},
-		{systems.System{Resource: "test"}, "system#resource=test", systems.System{Resource: "test"}, ""},
-		{systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("20.04/edge")}, "system#os=ubuntu#channel=20.04/edge", systems.System{OS: systems.Ubuntu, Channel: channel.MustParse("20.04/edge")}, ""},
+		{systems.Base{Name: systems.Ubuntu}, "ubuntu", systems.Base{}, `invalid base string "ubuntu": channel not valid`},
+		{systems.Base{Name: systems.Windows}, "windows", systems.Base{}, `invalid base string "windows": channel not valid`},
+		{systems.Base{Name: "mythicalos"}, "mythicalos", systems.Base{}, `series "mythicalos" not valid`},
+		{systems.Base{Name: systems.Ubuntu, Channel: channel.MustParse("20.04/stable")}, "focal", systems.Base{Name: systems.Ubuntu, Channel: channel.MustParse("20.04/stable")}, ""},
+		{systems.Base{Name: systems.Ubuntu, Channel: channel.MustParse("18.04/stable")}, "bionic", systems.Base{Name: systems.Ubuntu, Channel: channel.MustParse("18.04/stable")}, ""},
+		{systems.Base{Name: systems.Windows, Channel: channel.MustParse("win10/stable")}, "win10", systems.Base{Name: systems.Windows, Channel: channel.MustParse("win10/stable")}, ""},
+		{systems.Base{Name: systems.Ubuntu, Channel: channel.MustParse("20.04/edge")}, "ubuntu/20.04/edge", systems.Base{Name: systems.Ubuntu, Channel: channel.MustParse("20.04/edge")}, ""},
 	}
 	for i, v := range tests {
 		str := v.system.String()
 		comment := gc.Commentf("test %d", i)
 		c.Check(str, gc.Equals, v.str, comment)
-		s, err := systems.ParseSystemFromSeries(str)
+		s, err := systems.ParseBaseFromSeries(str)
 		if v.err != "" {
 			c.Check(err, gc.ErrorMatches, v.err, comment)
 		} else {
 			c.Check(err, jc.ErrorIsNil, comment)
 		}
-		c.Check(s, jc.DeepEquals, v.parsedSystem, comment)
+		c.Check(s, jc.DeepEquals, v.parsedBase, comment)
 	}
 }
 
 func (s *systemSuite) TestJSONEncoding(c *gc.C) {
-	sys := systems.System{
-		OS:       systems.Ubuntu,
-		Channel:  channel.MustParse("20.04/stable"),
-		Resource: "resource-name",
+	sys := systems.Base{
+		Name:    systems.Ubuntu,
+		Channel: channel.MustParse("20.04/stable"),
 	}
 	bytes, err := json.Marshal(sys)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(bytes), gc.Equals, `{"os":"ubuntu","channel":{"name":"20.04/stable","track":"20.04","risk":"stable"},"resource":"resource-name"}`)
-	sys2 := systems.System{}
+	c.Assert(string(bytes), gc.Equals, `{"name":"ubuntu","channel":{"name":"20.04/stable","track":"20.04","risk":"stable"}}`)
+	sys2 := systems.Base{}
 	err = json.Unmarshal(bytes, &sys2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sys2, jc.DeepEquals, sys)


### PR DESCRIPTION
Migrates System to Base. Mostly the same logic, but now we can store the Base as a series-compatible string by using the format: "os/track/risk/branch" e.g "ubuntu/18.04/stable/fips".

This will still try to preserve series representation e.g. "focal", "bionic" etc.